### PR TITLE
SuperUser Compatibility Fix

### DIFF
--- a/android_4.x/src/com/vipercn/viper4android_v2/activity/ShellCommand.java
+++ b/android_4.x/src/com/vipercn/viper4android_v2/activity/ShellCommand.java
@@ -562,6 +562,35 @@ public class ShellCommand
 		return nExitValue;
 	}
 
+    public static int RootExecuteWithoutShell(String szExecutable)
+    {
+        if (szExecutable == null) return -65536;
+        if (szExecutable.equals("")) return -65536;
+
+        Log.i("ViPER4Android_ShellCommand", "Root executing " + szExecutable + " ...");
+        int nExitValue = -65536;
+        try
+        {
+            Process psProg = Runtime.getRuntime().exec(new String[] {"su", "-c", szExecutable});
+            psProg.waitFor();
+            nExitValue = psProg.exitValue();
+            psProg.destroy();
+        }
+        catch (IOException e)
+        {
+            Log.i("ViPER4Android_ShellCommand", "IOException, msg = " + e.getMessage());
+            return nExitValue;
+        }
+        catch (InterruptedException e)
+        {
+            Log.i("ViPER4Android_ShellCommand", "InterruptedException, msg = " + e.getMessage());
+            return nExitValue;
+        }
+        Log.i("ViPER4Android_ShellCommand", "Program " + szExecutable + " returned " + nExitValue);
+
+        return nExitValue;
+    }
+
 	public static int RootExecuteWithoutShell(String szExecutable, File fDirectory)
 	{
 		if (szExecutable == null) return -65536;


### PR DESCRIPTION
NOTE - Sorry the changes in Utils.java seem so large my IDE really stuffed up the indenting somehow so I was forced to process the file using its auto-indent function, if you are not happy with this I can retype the modifications tomorrow and issue a new pull request.

This commit provides a work-around using existing methods to check for the presence
of Chainfire's SuperSU and if this is not found executes the root commands in a different
manner to take into account issues with SuperUser.

I have only implemented this within the VBOX installation method as this is where
I would experience all failed installs with SuperUser when debugging, if the RootTools
installation method also causes issues then the InstallDrv_FX method could be tweaked
to call the VBOX method if SuperSU is not installed thus using the modifed su command
structure.

Tested with both SuperUser & SuperSU with both functioning as expected, hopefully
this once and for all removes the issues faced with installing the driver using
SuperUser making the installation more user friendly and stopping about 90% of
posts on the xda thread which are all about the driver failing to install!! :)
