### PR TITLE
Android.mk for Integration with Custom ROM

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,1 @@
+include $(call all-subdir-makefiles)

--- a/android_2.3/Android.mk
+++ b/android_2.3/Android.mk
@@ -1,3 +1,5 @@
+ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \<= 9)))
+
 LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
@@ -12,3 +14,5 @@ include $(BUILD_PACKAGE)
 
 # Use the folloing include to make our test apk.
 include $(call all-makefiles-under,$(LOCAL_PATH))
+
+endif

--- a/android_4.x-5.x/Android.mk
+++ b/android_4.x-5.x/Android.mk
@@ -1,0 +1,55 @@
+ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \>= 14)))
+
+LOCAL_PATH:= $(call my-dir)
+
+#ViPER4Android
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_TAGS := optional
+
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+
+#LOCAL_RESOURCE_DIR += $(LOCAL_PATH)/res
+LOCAL_AAPT_FLAGS := --auto-add-overlay
+
+LOCAL_PACKAGE_NAME := ViPER4Android
+LOCAL_CERTIFICATE := platform
+
+LOCAL_PROGUARD_FLAG_FILES := proguard.flags
+
+LOCAL_STATIC_JAVA_LIBRARIES := \
+    v4a_RootTools \
+    v4a_android-support
+
+include $(BUILD_PACKAGE)
+
+#libs
+include $(CLEAR_VARS)
+
+LOCAL_PREBUILT_STATIC_JAVA_LIBRARIES := \
+    v4a_RootTools:libs/RootTools-4.2.jar \
+    v4a_android-support:libs/android-support-v13.jar
+
+include $(BUILD_MULTI_PREBUILT)
+
+#soundfx lib
+ifneq ($(filter NEON NEON_HQ NEON_SQ NOVFP VFP X86,$(VIPER4ANDROID_MODE)),)
+
+include $(CLEAR_VARS)
+
+ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \>= 21)))
+    LOCAL_V4A_LIB := libv4a_fx_jb
+else
+    LOCAL_V4A_LIB := libv4a_fx_ics
+endif
+
+LOCAL_MODULE := libv4a_fx_ics
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/soundfx
+LOCAL_MODULE_SUFFIX := .so
+LOCAL_SRC_FILES := assets/$(LOCAL_V4A_LIB)_$(VIPER4ANDROID_MODE).so
+include $(BUILD_PREBUILT)
+endif
+
+endif

--- a/android_4.x-5.x/Android.mk
+++ b/android_4.x-5.x/Android.mk
@@ -37,7 +37,7 @@ ifneq ($(filter NEON NEON_HQ NEON_SQ NOVFP VFP X86,$(VIPER4ANDROID_MODE)),)
 
 include $(CLEAR_VARS)
 
-ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \>= 21)))
+ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \>= 18)))
     LOCAL_V4A_LIB := libv4a_fx_jb
 else
     LOCAL_V4A_LIB := libv4a_fx_ics


### PR DESCRIPTION
Just a small patch to include some Android.mk files.
This is to permit inclusion of ViPER4Android into a manifest and to build it on a Custom ROM directly.
BoardConfig.mk on device tree should define a variable : VIPER4ANDROID_MODE that will permit to select the libv4a file to copy on the ROM.

eg:
VIPER4ANDROID_MODE := NEON_HQ