### PR TITLE
Android.mk: Support android_4.x build

### DIFF
--- a/android_4.x/Android.mk
+++ b/android_4.x/Android.mk
@@ -1,5 +1,5 @@
 ifeq (1,$(strip $(shell expr $(PLATFORM_SDK_VERSION) \>= 14)))
-ifeq ($(VIPER4ANDROID_FOLDER),android_4.x-5.x)
+ifneq ($(VIPER4ANDROID_FOLDER),android_4.x-5.x)
 
 LOCAL_PATH:= $(call my-dir)
 


### PR DESCRIPTION
Update 2.4.0.1 is only available under android_4.x and android_2.3 folders.

To provide the choice during AOSP inline compilation,
a new variable is available and can be set into BoardConfig

VIPER4ANDROID_FOLDER := android_4.x-5.x
VIPER4ANDROID_FOLDER := android_4.x

By default android_4.x will be used to compile ViPER4Android except for AOSP API <= 9
that will use android_2.3
